### PR TITLE
Prevent excessive memory allocation while decoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 sflow
 _collector/
+workdir/
+sflow-fuzz.zip

--- a/counter_sample.go
+++ b/counter_sample.go
@@ -94,6 +94,9 @@ func decodeCounterSample(r io.ReadSeeker) (Sample, error) {
 		if err != nil {
 			return nil, err
 		}
+		if length > MaximumRecordLength {
+			return nil, errors.New("Record length more than " + string(MaximumRecordLength) + ": " + string(length))
+		}
 
 		var rec Record
 

--- a/decoder.go
+++ b/decoder.go
@@ -15,8 +15,9 @@ const (
 
 	// MaximumHeaderLength defines the maximum length in bytes, acceptable for packet flow samples while decoding.
 	// This maximum prevents from excessive memory allocation for decoding.
-	// The value is set to maximum transmission unit (MTU), as the header of a network packet may not exceed the MTU.
-	MaximumHeaderLength = 1500
+	// The value is derived from INM_MAX_HEADER_SIZE 256 in sflow reference implementation
+	// https://github.com/sflow/sflowtool/blob/bd3df6e11bdf8261a42734c619abfe8b46e1202f/src/sflowtool.h#L28
+	MaximumHeaderLength = 256
 )
 
 var ErrUnsupportedDatagramVersion = errors.New("sflow: unsupported datagram version")

--- a/decoder.go
+++ b/decoder.go
@@ -15,9 +15,8 @@ const (
 
 	// MaximumHeaderLength defines the maximum length in bytes, acceptable for packet flow samples while decoding.
 	// This maximum prevents from excessive memory allocation for decoding.
-	// The value is derived from INM_MAX_HEADER_SIZE 256 in sflow reference implementation
-	// https://github.com/sflow/sflowtool/blob/bd3df6e11bdf8261a42734c619abfe8b46e1202f/src/sflowtool.h#L28
-	MaximumHeaderLength = 256
+	// The value is set to maximum transmission unit (MTU), as the header of a network packet may not exceed the MTU.
+	MaximumHeaderLength = 1500
 )
 
 var ErrUnsupportedDatagramVersion = errors.New("sflow: unsupported datagram version")

--- a/decoder.go
+++ b/decoder.go
@@ -6,6 +6,19 @@ import (
 	"io"
 )
 
+const (
+	// MaximumRecordLength defines the maximum length in bytes, acceptable for records while decoding.
+	// This maximum prevents from excessive memory allocation for decoding.
+	// The value is derived from MAX_PKT_SIZ 65536 in sflow reference implementation
+	// https://github.com/sflow/sflowtool/blob/bd3df6e11bdf8261a42734c619abfe8b46e1202f/src/sflowtool.c#L4313
+	MaximumRecordLength = 65536
+
+	// MaximumHeaderLength defines the maximum length in bytes, acceptable for packet flow samples while decoding.
+	// This maximum prevents from excessive memory allocation for decoding.
+	// The value is set to maximum transmission unit (MTU), as the header of a network packet may not exceed the MTU.
+	MaximumHeaderLength = 1500
+)
+
 var ErrUnsupportedDatagramVersion = errors.New("sflow: unsupported datagram version")
 
 type Decoder struct {

--- a/flow_record.go
+++ b/flow_record.go
@@ -2,6 +2,7 @@ package sflow
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -63,6 +64,9 @@ func decodeRawPacketFlow(r io.Reader) (RawPacketFlow, error) {
 	err = binary.Read(r, binary.BigEndian, &f.HeaderSize)
 	if err != nil {
 		return f, err
+	}
+	if f.HeaderSize > MaximumHeaderLength {
+		return f, errors.New("Header length more than " + string(MaximumHeaderLength) + ": " + string(f.HeaderSize))
 	}
 
 	padding := (4 - f.HeaderSize) % 4

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,17 @@
+// +build gofuzz
+
+package sflow
+
+import "bytes"
+
+// Fuzz function to be used with https://github.com/dvyukov/go-fuzz
+func Fuzz(data []byte) int {
+	
+	sflow := NewDecoder(bytes.NewReader(data))	
+	
+	if _, err := sflow.Decode(); err != nil {
+		return 0
+	}
+
+	return 1
+}


### PR DESCRIPTION
Enforce reasonable maximum values for record and header length while decoding sflow packets.

Fixes #29 